### PR TITLE
Fixed translation files

### DIFF
--- a/web/client/translations/data.de-DE.json
+++ b/web/client/translations/data.de-DE.json
@@ -104,6 +104,7 @@
                 "none": "Kein Tooltip",
                 "labelPlacement": "Platzierung",
                 "right": "Recht",
+                "left": "Links",
                 "bottom": "Bottom",
                 "top": "Oben"
             },

--- a/web/client/translations/data.es-ES.json
+++ b/web/client/translations/data.es-ES.json
@@ -102,6 +102,7 @@
                 "none": "Sin información sobre herramientas",
                 "labelPlacement": "Colocación",
                 "right": "Derecha",
+                "left": "Izquierda",
                 "bottom": "Bottom",
                 "top": "Cima"
             },


### PR DESCRIPTION
The issue happened because you added an entry to the english translation file, that is used as reference for mandatory translation files.
In this case the toopltip.left translation was missing in de and es translation files.

merge this PR to make your PR build again